### PR TITLE
Updated dockerfile to use ndk r28c (28.2.13676358)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN mv /usr/opt/android/cmdline-tools/cmdline-tools /usr/opt/android/cmdline-too
 RUN update-alternatives --config java
 
 ENV ANDROID_HOME /usr/opt/android
-ENV ANDROID_NDK_HOME ${ANDROID_HOME}/ndk/27.1.12297006
+ENV ANDROID_NDK_HOME ${ANDROID_HOME}/ndk/28.2.13676358
 ENV PATH /usr/opt/android/cmdline-tools/latest:/usr/opt/android/cmdline-tools/latest/bin:$PATH
 
 RUN which java
 RUN mkdir "$ANDROID_HOME/licenses" && echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_HOME/licenses/android-sdk-license" && sdkmanager --licenses
 
 RUN sdkmanager --list
-RUN sdkmanager "ndk;27.1.12297006" "platform-tools" "platforms;android-33"
+RUN sdkmanager "ndk;28.2.13676358" "platform-tools" "platforms;android-33"


### PR DESCRIPTION
https://developer.android.com/ndk/downloads#stable-downloads

Updated docker file to latest stable release of NDK 28